### PR TITLE
fix(deps): pin langfuse <3 and support moved CallbackHandler import

### DIFF
--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "langchain-mistralai>=0.2.3",
     "langchain-google-genai>=2.1.3",
     "fasttext-langdetect>=1.0.5",
-    "langfuse>=2.57.0",
+    "langfuse>=2.57.0,<3",
     "langchain-groq>=0.3.2",
 ]
 readme = "README.md"

--- a/core/quivr_core/rag/quivr_rag_langgraph.py
+++ b/core/quivr_core/rag/quivr_rag_langgraph.py
@@ -1136,9 +1136,9 @@ class QuivrQARAGLangGraph:
         chunk_metadata = get_chunk_metadata(rolling_message, docs)
         if metadata:
             chunk_metadata.langchain_metadata = metadata
-            chunk_metadata.langchain_metadata.langfuse_trace_url = (
-                langfuse_handler.get_trace_url()
-            )
+            get_url = getattr(langfuse_handler, "get_trace_url", None)
+            if callable(get_url):
+                chunk_metadata.langchain_metadata.langfuse_trace_url = get_url()
 
         yield ParsedRAGChunkResponse(
             answer="",

--- a/core/quivr_core/rag/utils.py
+++ b/core/quivr_core/rag/utils.py
@@ -4,7 +4,10 @@ from typing import Any, Dict, List, Tuple, no_type_check
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
 from langchain_core.messages.ai import AIMessageChunk
 from langchain_core.prompts import format_document
-from langfuse.callback import CallbackHandler
+try:
+    from langfuse.callback import CallbackHandler
+except ImportError:  # langfuse v3+/v4 moved the LangChain handler
+    from langfuse.langchain import CallbackHandler
 
 from quivr_core.rag.entities.config import WorkflowConfig
 from quivr_core.rag.entities.models import (


### PR DESCRIPTION
## Summary
`core/pyproject.toml` declared `langfuse>=2.57.0` with no upper bound while `utils.py` imports `CallbackHandler` from the removed `langfuse.callback` path. Fresh installs can resolve Langfuse v4 and fail at import time.

### Changes
- Pin `langfuse>=2.57.0,<3` for a safe default install
- Dual-import `CallbackHandler` from `langfuse.callback` with fallback to `langfuse.langchain`
- Soft-access `get_trace_url` when present on the handler

A full v4 migration can follow separately; this restores a working install first.

## Testing
- Dependency/import path review (host cannot install langfuse under PEP 668 without venv)

Fixes #3701


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins `langfuse` to <3 and adds a safe fallback for the moved `CallbackHandler` to restore working installs and prevent crashes with v4. Also guards `get_trace_url` access to handle API differences. Fixes #3701.

- **Bug Fixes**
  - Set `langfuse>=2.57.0,<3` to avoid resolving v4.
  - Fallback import: try `langfuse.callback.CallbackHandler`, else `langfuse.langchain.CallbackHandler`.
  - Only call `get_trace_url` if present to avoid attribute errors.

<sup>Written for commit 4b38c0ee51f5a723bd6ba8acf79f559521723f5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/QuivrHQ/quivr/pull/3702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

