### PR TITLE
feat: add MiniMax LLM provider with MiniMax-M3 and MiniMax-M2.7

### DIFF
--- a/core/quivr_core/llm/llm_endpoint.py
+++ b/core/quivr_core/llm/llm_endpoint.py
@@ -19,6 +19,12 @@ from quivr_core.rag.utils import model_supports_function_calling
 
 logger = logging.getLogger("quivr_core")
 
+_MINIMAX_OPENAI_BASE_URL = "https://api.minimax.io/v1"
+_MINIMAX_ANTHROPIC_BASE_URLS = {
+    "https://api.minimax.io/anthropic",
+    "https://api.minimaxi.com/anthropic",
+}
+
 
 class LLMTokenizer:
     _cache: dict[
@@ -221,7 +227,7 @@ class LLMEndpoint:
             ChatMistralAI,
             ChatGoogleGenerativeAI,
             ChatGroq,
-        ]  # MiniMax reuses ChatOpenAI against its OpenAI-compatible endpoint
+        ]
         try:
             if config.supplier == DefaultModelSuppliers.AZURE:
                 # Parse the URL
@@ -292,15 +298,28 @@ class LLMEndpoint:
                     temperature=config.temperature,
                 )
             elif config.supplier == DefaultModelSuppliers.MINIMAX:
-                _llm = ChatOpenAI(
-                    model=config.model,
-                    api_key=SecretStr(config.llm_api_key)
-                    if config.llm_api_key
-                    else None,
-                    base_url=config.llm_base_url or "https://api.minimax.io/v1",
-                    max_completion_tokens=config.max_output_tokens,
-                    temperature=config.temperature,
-                )
+                base_url = (config.llm_base_url or _MINIMAX_OPENAI_BASE_URL).rstrip("/")
+                if base_url in _MINIMAX_ANTHROPIC_BASE_URLS:
+                    assert config.llm_api_key, "Can't load model config"
+                    _llm = ChatAnthropic(
+                        model_name=config.model,
+                        api_key=SecretStr(config.llm_api_key),
+                        base_url=base_url,
+                        max_tokens_to_sample=config.max_output_tokens,
+                        temperature=config.temperature,
+                        timeout=None,
+                        stop=None,
+                    )
+                else:
+                    _llm = ChatOpenAI(
+                        model=config.model,
+                        api_key=SecretStr(config.llm_api_key)
+                        if config.llm_api_key
+                        else None,
+                        base_url=base_url,
+                        max_completion_tokens=config.max_output_tokens,
+                        temperature=config.temperature,
+                    )
 
             else:
                 _llm = ChatOpenAI(

--- a/core/quivr_core/llm/llm_endpoint.py
+++ b/core/quivr_core/llm/llm_endpoint.py
@@ -221,7 +221,7 @@ class LLMEndpoint:
             ChatMistralAI,
             ChatGoogleGenerativeAI,
             ChatGroq,
-        ]
+        ]  # MiniMax reuses ChatOpenAI against its OpenAI-compatible endpoint
         try:
             if config.supplier == DefaultModelSuppliers.AZURE:
                 # Parse the URL
@@ -289,6 +289,16 @@ class LLMEndpoint:
                     else None,
                     base_url=config.llm_base_url,
                     max_tokens=config.max_output_tokens,
+                    temperature=config.temperature,
+                )
+            elif config.supplier == DefaultModelSuppliers.MINIMAX:
+                _llm = ChatOpenAI(
+                    model=config.model,
+                    api_key=SecretStr(config.llm_api_key)
+                    if config.llm_api_key
+                    else None,
+                    base_url=config.llm_base_url or "https://api.minimax.io/v1",
+                    max_completion_tokens=config.max_output_tokens,
                     temperature=config.temperature,
                 )
 

--- a/core/quivr_core/rag/entities/config.py
+++ b/core/quivr_core/rag/entities/config.py
@@ -75,6 +75,7 @@ class DefaultModelSuppliers(str, Enum):
     MISTRAL = "mistral"
     GROQ = "groq"
     GEMINI = "gemini"
+    MINIMAX = "minimax"
 
 
 class LLMConfig(QuivrBaseConfig):
@@ -273,6 +274,16 @@ class LLMModelConfig:
                 max_context_tokens=128000,
                 max_output_tokens=4096,
                 tokenizer_hub="Quivr/gemini-tokenizer",
+            ),
+        },
+        DefaultModelSuppliers.MINIMAX: {
+            "MiniMax-M3": LLMConfig(
+                max_context_tokens=1000000,
+                max_output_tokens=None,
+            ),
+            "MiniMax-M2.7": LLMConfig(
+                max_context_tokens=204800,
+                max_output_tokens=None,
             ),
         },
     }

--- a/core/tests/test_llm_endpoint.py
+++ b/core/tests/test_llm_endpoint.py
@@ -3,7 +3,7 @@ import os
 import pytest
 from langchain_core.language_models import FakeListChatModel
 from pydantic import ValidationError
-from quivr_core.rag.entities.config import LLMEndpointConfig
+from quivr_core.rag.entities.config import DefaultModelSuppliers, LLMEndpointConfig
 from quivr_core.llm import LLMEndpoint
 
 
@@ -46,3 +46,37 @@ def test_llm_endpoint_constructor():
     )
 
     assert not llm_endpoint.supports_func_calling()
+
+
+@pytest.mark.base
+def test_llm_endpoint_minimax_default_base_url():
+    from langchain_openai import ChatOpenAI
+
+    config = LLMEndpointConfig(
+        supplier=DefaultModelSuppliers.MINIMAX,
+        model="MiniMax-M3",
+        llm_api_key="test",
+    )
+    llm = LLMEndpoint.from_config(config)
+
+    assert isinstance(llm._llm, ChatOpenAI)
+    assert llm._llm.model_name == "MiniMax-M3"
+    assert str(llm._llm.openai_api_base) == "https://api.minimax.io/v1"
+    assert llm.supports_func_calling()
+
+
+@pytest.mark.base
+def test_llm_endpoint_minimax_custom_base_url():
+    from langchain_openai import ChatOpenAI
+
+    config = LLMEndpointConfig(
+        supplier=DefaultModelSuppliers.MINIMAX,
+        model="MiniMax-M2.7",
+        llm_api_key="test",
+        llm_base_url="https://api.minimaxi.com/v1",
+    )
+    llm = LLMEndpoint.from_config(config)
+
+    assert isinstance(llm._llm, ChatOpenAI)
+    assert llm._llm.model_name == "MiniMax-M2.7"
+    assert str(llm._llm.openai_api_base) == "https://api.minimaxi.com/v1"

--- a/core/tests/test_llm_endpoint.py
+++ b/core/tests/test_llm_endpoint.py
@@ -56,12 +56,14 @@ def test_llm_endpoint_minimax_default_base_url():
         supplier=DefaultModelSuppliers.MINIMAX,
         model="MiniMax-M3",
         llm_api_key="test",
+        max_context_tokens=2_000_000,
     )
     llm = LLMEndpoint.from_config(config)
 
     assert isinstance(llm._llm, ChatOpenAI)
     assert llm._llm.model_name == "MiniMax-M3"
-    assert str(llm._llm.client.base_url).rstrip("/") == "https://api.minimax.io/v1"
+    assert str(llm._llm.root_client.base_url).rstrip("/") == "https://api.minimax.io/v1"
+    assert config.max_context_tokens == 1_000_000
     assert llm.supports_func_calling()
 
 
@@ -74,9 +76,37 @@ def test_llm_endpoint_minimax_custom_base_url():
         model="MiniMax-M2.7",
         llm_api_key="test",
         llm_base_url="https://api.minimaxi.com/v1",
+        max_context_tokens=2_000_000,
     )
     llm = LLMEndpoint.from_config(config)
 
     assert isinstance(llm._llm, ChatOpenAI)
     assert llm._llm.model_name == "MiniMax-M2.7"
-    assert str(llm._llm.client.base_url).rstrip("/") == "https://api.minimaxi.com/v1"
+    assert (
+        str(llm._llm.root_client.base_url).rstrip("/") == "https://api.minimaxi.com/v1"
+    )
+    assert config.max_context_tokens == 204_800
+
+
+@pytest.mark.base
+@pytest.mark.parametrize(
+    ("model", "base_url"),
+    [
+        ("MiniMax-M3", "https://api.minimax.io/anthropic"),
+        ("MiniMax-M2.7", "https://api.minimaxi.com/anthropic"),
+    ],
+)
+def test_llm_endpoint_minimax_anthropic_base_urls(model: str, base_url: str):
+    from langchain_anthropic import ChatAnthropic
+
+    config = LLMEndpointConfig(
+        supplier=DefaultModelSuppliers.MINIMAX,
+        model=model,
+        llm_api_key="test",
+        llm_base_url=base_url,
+    )
+    llm = LLMEndpoint.from_config(config)
+
+    assert isinstance(llm._llm, ChatAnthropic)
+    assert llm._llm.model == model
+    assert str(llm._llm.anthropic_api_url).rstrip("/") == base_url

--- a/core/tests/test_llm_endpoint.py
+++ b/core/tests/test_llm_endpoint.py
@@ -61,7 +61,7 @@ def test_llm_endpoint_minimax_default_base_url():
 
     assert isinstance(llm._llm, ChatOpenAI)
     assert llm._llm.model_name == "MiniMax-M3"
-    assert str(llm._llm.openai_api_base) == "https://api.minimax.io/v1"
+    assert str(llm._llm.client.base_url).rstrip("/") == "https://api.minimax.io/v1"
     assert llm.supports_func_calling()
 
 
@@ -79,4 +79,4 @@ def test_llm_endpoint_minimax_custom_base_url():
 
     assert isinstance(llm._llm, ChatOpenAI)
     assert llm._llm.model_name == "MiniMax-M2.7"
-    assert str(llm._llm.openai_api_base) == "https://api.minimaxi.com/v1"
+    assert str(llm._llm.client.base_url).rstrip("/") == "https://api.minimaxi.com/v1"


### PR DESCRIPTION
Reason: provider-add — add the MiniMax LLM provider with its current text models and documented OpenAI-compatible endpoints.

## Changes

- Add `MINIMAX` to `DefaultModelSuppliers` in `core/quivr_core/rag/entities/config.py`.
- Register `MiniMax-M3` (1,000,000 context window) and `MiniMax-M2.7` (204,800 context window) under the new MiniMax supplier in `LLMModelConfig._model_defaults`.
- Add a `DefaultModelSuppliers.MINIMAX` branch in `LLMEndpoint.from_config` that instantiates `ChatOpenAI` against MiniMax's OpenAI-compatible endpoint, defaulting `base_url` to the documented global endpoint (`https://api.minimax.io/v1`) when no explicit `llm_base_url` is configured. Users can override `llm_base_url` to target the documented China region endpoint (`https://api.minimaxi.com/v1`).
- Add unit tests in `core/tests/test_llm_endpoint.py` covering the MiniMax default base URL and a custom (China region) base URL for both `MiniMax-M3` and `MiniMax-M2.7`.

## Checks

- Syntax validation passes for all modified files (`python -m ast`).
- `pytest tests/test_llm_endpoint.py -m base` — the two new MiniMax tests pass (`test_llm_endpoint_minimax_default_base_url`, `test_llm_endpoint_minimax_custom_base_url`). Pre-existing `test_llm_endpoint_from_config_default` failure is unrelated (newer `openai` SDK in the local env raises `OpenAIError` instead of `ValidationError`).
- Verified `LLMModelConfig.get_llm_model_config` and `get_supplier_by_model_name` resolve the MiniMax models and supplier correctly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the MiniMax LLM provider with `MiniMax-M3` (1,000,000 tokens) and `MiniMax-M2.7` (204,800), supporting both OpenAI- and Anthropic-compatible MiniMax endpoints. Defaults to https://api.minimax.io/v1, with China and Anthropic endpoints selectable via `llm_base_url`.

- **New Features**
  - Added `MINIMAX` to `DefaultModelSuppliers` and model defaults for `MiniMax-M3` and `MiniMax-M2.7`.
  - In `LLMEndpoint.from_config`, use `ChatOpenAI` from `langchain_openai` for OpenAI endpoints (default `https://api.minimax.io/v1`, override via `llm_base_url`), and `ChatAnthropic` from `langchain_anthropic` when `llm_base_url` is `https://api.minimax.io/anthropic` or `https://api.minimaxi.com/anthropic`.
  - Added tests for default/custom base URLs, Anthropic routing, and function-calling support.

<sup>Written for commit ca98ccd5bb51a234db15a81d8a5dbca26397e3f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/QuivrHQ/quivr/pull/3704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

