### PR TITLE
docs: fix examples to match current quivr-core API + fix Megaparse error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ reranker_config:
 llm_config:
 
   # maximum number of tokens passed to the LLM to generate the answer
-  max_input_tokens: 4000
+  max_context_tokens: 8000
 
   # temperature for the LLM
   temperature: 0.7
@@ -155,7 +155,7 @@ brain.print_info()
 from rich.console import Console
 from rich.panel import Panel
 from rich.prompt import Prompt
-from quivr_core.config import RetrievalConfig
+from quivr_core.rag.entities.config import RetrievalConfig
 
 config_file_name = "./basic_rag_workflow.yaml"
 

--- a/core/quivr_core/brain/brain_defaults.py
+++ b/core/quivr_core/brain/brain_defaults.py
@@ -34,12 +34,12 @@ def default_embedder() -> Embeddings:
     try:
         from langchain_openai import OpenAIEmbeddings
 
-        logger.debug("Loaded OpenAIEmbeddings as default LLM for brain")
+        logger.debug("Loaded OpenAIEmbeddings as default embedder for brain")
         embedder = OpenAIEmbeddings()
         return embedder
     except ImportError as e:
         raise ImportError(
-            "Please provide a valid Embedder or install quivr-core['base'] package for using the defaultone."
+            "Please provide a valid Embedder or install quivr-core['base'] package for using the default one."
         ) from e
 
 

--- a/core/quivr_core/processor/registry.py
+++ b/core/quivr_core/processor/registry.py
@@ -141,7 +141,7 @@ def defaults_to_proc_entries(
             FileExtension.mdx,
         ],
         cls_mod="quivr_core.processor.implementations.megaparse_processor.MegaparseProcessor",
-        errtxt=f"can't import MegaparseProcessor. Please install quivr-core[{ext_str}] to access MegaparseProcessor",
+        errtxt="can't import MegaparseProcessor. Please install quivr-core[megaparse] to access MegaparseProcessor",
         priority=None,
     )
     return base_processors

--- a/docs/docs/brain/index.md
+++ b/docs/docs/brain/index.md
@@ -6,7 +6,7 @@ Quick Start 🪄:
 
 ```python
 from quivr_core import Brain
-from quivr_core.quivr_rag_langgraph import QuivrQARAGLangGraph
+from quivr_core.rag.quivr_rag_langgraph import QuivrQARAGLangGraph
 
 
 brain = Brain.from_files(name="My Brain", file_paths=["file1.pdf", "file2.pdf"])
@@ -20,9 +20,9 @@ Pimp your Brain 🔨 :
 ```python
 from quivr_core import Brain
 from quivr_core.llm.llm_endpoint import LLMEndpoint
-from quivr_core.embedder.embedder import DeterministicFakeEmbedding
+from langchain_core.embeddings import DeterministicFakeEmbedding
 from quivr_core.llm.llm_endpoint import LLMEndpointConfig
-from quivr_core.llm.llm_endpoint import FakeListChatModel
+from langchain_core.language_models import FakeListChatModel
 
 brain = Brain.from_files(
         name="test_brain",

--- a/docs/docs/config/index.md
+++ b/docs/docs/config/index.md
@@ -39,7 +39,7 @@ reranker_config:
   top_n: 5
 llm_config:
 
-  max_context_tokens: 2000
+  max_context_tokens: 8000
 
   temperature: 0.7
   streaming: true

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -72,11 +72,11 @@ Note : [Embeddings](https://python.langchain.com/docs/integrations/text_embeddin
 
 ## Launch with Chainlit
 
-If you want to quickly launch an interface with streamlit, you can simply do at the root of the project :
+If you want to quickly launch an interface with chainlit, you can simply do at the root of the project :
 ```bash
-cd examples/chatbot /
-rye sync /
-rye run chainlit run chainlit.py
+cd examples/chatbot
+rye sync
+rye run chainlit run main.py
 ```
 For more detail, go in [examples/chatbot/chainlit.md](https://github.com/QuivrHQ/quivr/tree/main/examples/chatbot)
 

--- a/docs/docs/workflows/examples/basic_ingestion.md
+++ b/docs/docs/workflows/examples/basic_ingestion.md
@@ -27,7 +27,7 @@ parser_config:
 3. Create a Brain using the above configuration and the list of files you want to ingest
 ```python
 from quivr_core import Brain
-from quivr_core.config import IngestionConfig
+from quivr_core.rag.entities.config import IngestionConfig
 
 config_file_name = "./basic_ingestion_workflow.yaml"
 

--- a/docs/docs/workflows/examples/basic_rag.md
+++ b/docs/docs/workflows/examples/basic_rag.md
@@ -53,7 +53,7 @@ reranker_config:
 llm_config:
 
   # maximum number of tokens passed to the LLM to generate the answer
-  max_input_tokens: 4000
+  max_context_tokens: 8000
 
   # temperature for the LLM
   temperature: 0.7
@@ -76,7 +76,7 @@ brain.print_info()
 from rich.console import Console
 from rich.panel import Panel
 from rich.prompt import Prompt
-from quivr_core.config import RetrievalConfig
+from quivr_core.rag.entities.config import RetrievalConfig
 
 config_file_name = "./basic_rag_workflow.yaml"
 

--- a/docs/docs/workflows/examples/rag_with_web_search.md
+++ b/docs/docs/workflows/examples/rag_with_web_search.md
@@ -83,7 +83,7 @@ reranker_config:
 llm_config:
 
   # maximum number of tokens passed to the LLM to generate the answer
-  max_input_tokens: 8000
+  max_context_tokens: 8000
 
   # temperature for the LLM
   temperature: 0.7
@@ -106,7 +106,7 @@ brain.print_info()
 from rich.console import Console
 from rich.panel import Panel
 from rich.prompt import Prompt
-from quivr_core.config import RetrievalConfig
+from quivr_core.rag.entities.config import RetrievalConfig
 
 config_file_name = "./rag_with_web_search_workflow.yaml"
 


### PR DESCRIPTION
## Summary
All verified against `core/quivr_core` at HEAD:

- **Import paths**: `RetrievalConfig` / `IngestionConfig` live in `quivr_core.rag.entities.config`, not `quivr_core.config` (which only has Megaparse settings). Fixed in `README.md` and three `docs/docs/workflows/examples/*.md` files. Following the docs as written raises `ImportError`.
- **YAML config key**: documented `llm_config.max_input_tokens` doesn't exist (`LLMEndpointConfig` has `max_context_tokens` and is `extra="forbid"`), so `RetrievalConfig.from_yaml()` on the documented YAML raises a pydantic `ValidationError`. Also `4000` is below `MIN_CONTEXT_TOKENS = 4096` and trips the `ValueError` in `set_llm_model_config`. Renamed the key and used `8000` (also fixed `docs/docs/config/index.md` which showed `2000`).
- **quickstart**: the "Launch with Chainlit" section says *streamlit*, runs `chainlit run chainlit.py` (the file is `main.py`, per `examples/chatbot/README.md`), and has stray `/` at end of lines.
- **brain docs**: fixed three imports (`quivr_core.rag.quivr_rag_langgraph`; the fake embedder/LLM come from `langchain_core`, there is no `quivr_core.embedder` package).
- **`registry.py`**: the Megaparse `errtxt` referenced `ext_str` after the loop it belongs to, so every failure logs "install quivr-core[.ipynb]". Now suggests `quivr-core[megaparse]`.
- **`brain_defaults.py`**: log line said "default LLM" when loading the embedder; fixed "defaultone" typo in the `ImportError`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns docs and examples with the current `quivr_core` API and fixes Megaparse install hint and logging copy. Old docs used `quivr_core.config` and `llm_config.max_input_tokens`, which caused `ImportError`/`ValidationError`; new docs import from `quivr_core.rag.entities.config` and use `max_context_tokens` (examples use 8000).

- Update your YAML: rename `llm_config.max_input_tokens` to `llm_config.max_context_tokens` and use a value >= 4096 (examples use 8000).
- Update imports: use `from quivr_core.rag.entities.config import RetrievalConfig, IngestionConfig`; brain examples import `QuivrQARAGLangGraph` from `quivr_core.rag.quivr_rag_langgraph` and fakes from `langchain_core`.
- Quickstart: run `rye run chainlit run main.py` in `examples/chatbot` (no trailing slashes).
- Megaparse error message now correctly suggests installing `quivr-core[megaparse]`; brain default embedder log and ImportError text are corrected.

<sup>Written for commit c11819dfc046f2021efabcab2fe6ceb5e4098df7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/QuivrHQ/quivr/pull/3710?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

