### PR TITLE
fix(storage): create brain directories before upload

### DIFF
--- a/core/quivr_core/storage/local_storage.py
+++ b/core/quivr_core/storage/local_storage.py
@@ -78,6 +78,8 @@ class LocalStorage(StorageBase):
         if file.file_sha1 in self.hashes and not exists_ok:
             raise FileExistsError(f"file {file.original_filename} already uploaded")
 
+        Path(dst_path).parent.mkdir(parents=True, exist_ok=True)
+
         if self.copy_flag:
             shutil.copy2(file.path, dst_path)
         else:

--- a/core/tests/test_local_storage.py
+++ b/core/tests/test_local_storage.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from quivr_core.files.file import QuivrFile
+from quivr_core.storage.local_storage import LocalStorage
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("copy_flag", [True, False])
+async def test_upload_file_creates_brain_directory(tmp_path: Path, copy_flag: bool):
+    source_path = tmp_path / "source.txt"
+    source_path.write_text("stored content")
+    brain_id = uuid4()
+    file_id = uuid4()
+    qfile = QuivrFile(
+        id=file_id,
+        brain_id=brain_id,
+        original_filename=source_path.name,
+        path=source_path,
+        file_extension=".txt",
+        file_sha1="sha1",
+    )
+    storage = LocalStorage(dir_path=tmp_path / "storage", copy_flag=copy_flag)
+
+    await storage.upload_file(qfile)
+
+    stored_path = tmp_path / "storage" / str(brain_id) / f"{file_id}.txt"
+    assert stored_path.read_text() == "stored content"
+    assert qfile.path == stored_path


### PR DESCRIPTION
# Description

`LocalStorage.upload_file()` stores each file below a per-brain directory, but
that directory was never created. As a result, the first upload for a brain
raised `FileNotFoundError` in both copy and symlink modes.

This change creates the destination parent directory immediately before the
copy or symlink operation. It also adds a deterministic regression test for
both storage modes.

Related issue: none.

## Regression evidence

- Before: `cd core && OPENAI_API_KEY=this-is-a-test-key .venv/bin/pytest tests/test_local_storage.py -q` — 2 failed.
- After: the same command — 2 passed.

## Verification

- `cd core && OPENAI_API_KEY=this-is-a-test-key .venv/bin/pytest tests/test_local_storage.py tests/test_quivr_file.py -q` — 4 passed.
- `core/.venv/bin/pre-commit run --files core/quivr_core/storage/local_storage.py core/tests/test_local_storage.py` — passed, including Ruff and mypy hooks.
- `cd core && uv build` followed by `twine check` on both artifacts — passed.
- Full suite: the same 11 pre-existing tests fail on both the base and patched trees; the patched tree adds only the two passing regression cases (base: 29 passed, 13 skipped; patched: 31 passed, 13 skipped), so this change introduces no new failures.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ideally added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (see the pre-existing full-suite baseline above)

## Screenshots (if appropriate):

Not applicable.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `LocalStorage.upload_file()` throwing `FileNotFoundError` on the first upload for a brain because the per-brain destination directory was never created. The parent directory is now created before the copy or symlink, and a regression test covers both storage modes.

<sup>Written for commit 0f79187e7dd47824125b4d9b372d75838d5724d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Vibe-Company/Quivr/pull/3715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

